### PR TITLE
fix: correct operation in declareViewController

### DIFF
--- a/packages/rx-effects/src/mvc.test.ts
+++ b/packages/rx-effects/src/mvc.test.ts
@@ -127,9 +127,12 @@ describe('declareViewController()', () => {
     const controllerFactory = declareViewController(
       { value: VALUE_TOKEN },
       ({ value }) =>
-        (scope, arg: Query<number>) => ({
-          getValue: () => value * 10 + arg.get(),
-        }),
+        (scope, arg: Query<number>) => {
+          const $value = scope.createStore(10);
+          return {
+            getValue: () => value * $value.get() + arg.get(),
+          };
+        },
     );
 
     const container = createContainer();

--- a/packages/rx-effects/src/mvc.test.ts
+++ b/packages/rx-effects/src/mvc.test.ts
@@ -107,9 +107,13 @@ describe('declareViewController()', () => {
   });
 
   it('should create a factory without DI dependencies', () => {
-    const controllerFactory = declareViewController(() => ({
-      getValue: () => 10,
-    }));
+    const controllerFactory = declareViewController((scope) => {
+      const $value = scope.createStore(10);
+
+      return {
+        getValue: () => $value.get(),
+      };
+    });
 
     const container = createContainer();
 

--- a/packages/rx-effects/src/mvc.ts
+++ b/packages/rx-effects/src/mvc.ts
@@ -90,17 +90,15 @@ export function declareViewController<
   tokensOrFactory: TokenProps<Dependencies> | Factory,
   factory?: FactoryWithDependencies,
 ): ViewControllerFactory<Service, Params> {
-  const tokensValue = (
-    factory ? tokensOrFactory : {}
-  ) as TokenProps<Dependencies>;
-
   return (container: Container, ...params: Params) => {
+    if (typeof tokensOrFactory === 'function') {
+      return createController((scope) => {
+        return tokensOrFactory(scope, ...params);
+      });
+    }
+
     return injectable((dependencies) => {
       return createController((scope) => {
-        if (typeof tokensOrFactory === 'function') {
-          return tokensOrFactory(scope, ...params);
-        }
-
         const factoryValue = factory as FactoryWithDependencies;
 
         const result = factoryValue(dependencies as Dependencies, scope);
@@ -110,6 +108,6 @@ export function declareViewController<
         }
         return result;
       });
-    }, tokensValue)(container);
+    }, tokensOrFactory)(container);
   };
 }

--- a/packages/rx-effects/src/mvc.ts
+++ b/packages/rx-effects/src/mvc.ts
@@ -73,7 +73,7 @@ export function declareViewController<
     deps: Dependencies,
     scope: Scope,
   ) => ((scope: Scope, ...params: Params) => Service) | Service,
-): ViewControllerFactory<Service, unknown[]>;
+): ViewControllerFactory<Service, Params>;
 
 export function declareViewController<
   Dependencies extends DependencyProps,


### PR DESCRIPTION
When i use declareViewController with scope as first argument then i catch exception

```js
const CONTROLLER = declareViewController((scope) => {
   const $state = scope.createStore(...)
   ....
}
```

**TypeError**
scope.createStore is not a function

my commit fix this error