### PR TITLE
fix: Fixed rerendering by `useObserver()` and reduced excess unsubscribe/subscribe on rerendering a parent component

### DIFF
--- a/packages/rx-effects-react/src/index.ts
+++ b/packages/rx-effects-react/src/index.ts
@@ -1,7 +1,7 @@
 export * from './useConst';
 export * from './useController';
 export * from './useObservable';
-export * from './useObserver';
+export { useObserver } from './useObserver';
 export * from './useSelector';
 export * from './useQuery';
 export * from './useStore';

--- a/packages/rx-effects-react/src/useObserver.test.ts
+++ b/packages/rx-effects-react/src/useObserver.test.ts
@@ -50,6 +50,39 @@ describe('useObserver()', () => {
     expect(listener2).toHaveBeenCalledTimes(1);
   });
 
+  it('should resubscribe if a only source is changed 2', () => {
+    const sourceNext$ = new BehaviorSubject(1);
+
+    expect(() => {
+      renderHook(() =>
+        useObserver(sourceNext$, {
+          next: undefined,
+        }),
+      );
+      sourceNext$.next(1);
+    }).not.toThrow();
+
+    const sourceError$ = new BehaviorSubject(1);
+    expect(() => {
+      renderHook(() =>
+        useObserver(sourceError$, {
+          error: undefined,
+        }),
+      );
+      sourceError$.error(new Error('some error'));
+    }).not.toThrow();
+
+    const sourceComplete$ = new BehaviorSubject(1);
+    expect(() => {
+      renderHook(() =>
+        useObserver(sourceComplete$, {
+          complete: undefined,
+        }),
+      );
+      sourceComplete$.complete();
+    }).not.toThrow();
+  });
+
   it('should subscribe to error', () => {
     const source$ = new Subject();
     const observer: PartialObserver<unknown> = {

--- a/packages/rx-effects-react/src/useObserver.test.ts
+++ b/packages/rx-effects-react/src/useObserver.test.ts
@@ -50,7 +50,7 @@ describe('useObserver()', () => {
     expect(listener2).toHaveBeenCalledTimes(1);
   });
 
-  it('should resubscribe if a only source is changed 2', () => {
+  it('should handled it all variants of the listener', () => {
     const sourceNext$ = new BehaviorSubject(1);
 
     expect(() => {
@@ -59,6 +59,8 @@ describe('useObserver()', () => {
           next: undefined,
         }),
       );
+      renderHook(() => useObserver(sourceNext$, undefined as any));
+
       sourceNext$.next(1);
     }).not.toThrow();
 
@@ -69,6 +71,7 @@ describe('useObserver()', () => {
           error: undefined,
         }),
       );
+      renderHook(() => useObserver(sourceError$, undefined as any));
       sourceError$.error(new Error('some error'));
     }).not.toThrow();
 
@@ -79,6 +82,7 @@ describe('useObserver()', () => {
           complete: undefined,
         }),
       );
+      renderHook(() => useObserver(sourceComplete$, undefined as any));
       sourceComplete$.complete();
     }).not.toThrow();
   });

--- a/packages/rx-effects-react/src/useObserver.test.ts
+++ b/packages/rx-effects-react/src/useObserver.test.ts
@@ -50,22 +50,6 @@ describe('useObserver()', () => {
     expect(listener2).toHaveBeenCalledTimes(1);
   });
 
-  it('should check window', () => {
-    const isBrowserFalsy = isBrowser();
-    expect(isBrowserFalsy).toBeFalsy();
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    global.window = {};
-
-    const isBrowserTruthy = isBrowser();
-    expect(isBrowserTruthy).toBeTruthy();
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    delete global.window;
-  });
-
   it('should subscribe to error', () => {
     const source$ = new Subject();
     const observer: PartialObserver<unknown> = {
@@ -189,5 +173,23 @@ describe('useObserver()', () => {
     expect(listener1).toHaveBeenCalledWith(1);
 
     expect(listener2).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('isBrowser()', () => {
+  it('should return true when the window exists', () => {
+    const isBrowserFalsy = isBrowser();
+    expect(isBrowserFalsy).toBeFalsy();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    global.window = {};
+
+    const isBrowserTruthy = isBrowser();
+    expect(isBrowserTruthy).toBeTruthy();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete global.window;
   });
 });

--- a/packages/rx-effects-react/src/useObserver.test.ts
+++ b/packages/rx-effects-react/src/useObserver.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { BehaviorSubject, PartialObserver, Subject } from 'rxjs';
-import { useObserver } from './useObserver';
+import { isBrowser, useObserver } from './useObserver';
 
 describe('useObserver()', () => {
   it('should subscribe a listener for next values', () => {
@@ -48,6 +48,31 @@ describe('useObserver()', () => {
     source2$.next(1);
     expect(listener2).toHaveBeenNthCalledWith(1, 1);
     expect(listener2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should check window', async () => {
+    const isBrowserFalsy = isBrowser();
+    expect(isBrowserFalsy).toBeFalsy();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    global.window = {};
+
+    const isBrowserTruthy = isBrowser();
+    expect(isBrowserTruthy).toBeTruthy();
+  });
+
+  it('should subscribe to error', () => {
+    const source$ = new Subject();
+    const observer: PartialObserver<unknown> = {
+      error: jest.fn(),
+    };
+
+    renderHook(() => useObserver(source$, observer));
+
+    source$.error(new Error('some error'));
+
+    expect(observer.error).toHaveBeenCalledTimes(1);
   });
 
   it('should return a subscription', () => {

--- a/packages/rx-effects-react/src/useObserver.ts
+++ b/packages/rx-effects-react/src/useObserver.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Observable, Observer, Subscription } from 'rxjs';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { Observable, PartialObserver, Subscription } from 'rxjs';
 import { useConst } from './useConst';
 
 /**
@@ -12,28 +12,72 @@ import { useConst } from './useConst';
  *
  * @example
  * ```ts
- * const observer = useCallback((nextValue) => {
+ * useObserver(source$, (nextValue) => {
  *   logger.log(nextValue);
- * }, []);
- * useObserver(source$, observer);
+ * });
  * ```
  */
 export function useObserver<T>(
   source$: Observable<T>,
-  observerOrNext: Partial<Observer<T>> | ((value: T) => void),
+  observerOrNext: PartialObserver<T> | ((value: T) => void),
 ): Subscription {
   const hookSubscriptions = useConst(() => new Subscription());
 
+  const argsRef = useRef<
+    [Observable<T>, PartialObserver<T> | ((value: T) => void)]
+  >([source$, observerOrNext]);
+
+  // Update the latest observable and callbacks
+  // synchronously after render being committed
+  useIsomorphicLayoutEffect(() => {
+    argsRef.current = [source$, observerOrNext];
+  });
+
   useEffect(() => {
     if (!hookSubscriptions.closed) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: subscribe cannot infer the right type.
-      const subscription = source$.subscribe(observerOrNext);
+      const input$ = argsRef.current[0];
+
+      const subscription = input$.subscribe({
+        next: (value) => {
+          if (input$ !== argsRef.current[0]) {
+            // stale observable
+            return;
+          }
+          const nextObserver =
+            (argsRef.current[1] as PartialObserver<T>)?.next ||
+            (argsRef.current[1] as ((value: T) => void) | null | undefined);
+          if (nextObserver) {
+            return nextObserver(value);
+          }
+        },
+        error: (error) => {
+          if (input$ !== argsRef.current[0]) {
+            // stale observable
+            return;
+          }
+          const errorObserver = (argsRef.current[1] as PartialObserver<T>)
+            ?.error;
+          if (errorObserver) {
+            return errorObserver(error);
+          }
+        },
+        complete: () => {
+          if (input$ !== argsRef.current[0]) {
+            // stale observable
+            return;
+          }
+          const completeObserver = (argsRef.current[1] as PartialObserver<T>)
+            ?.complete;
+          if (completeObserver) {
+            return completeObserver();
+          }
+        },
+      });
       hookSubscriptions.add(subscription);
       return () => subscription.unsubscribe();
     }
     return undefined;
-  }, [hookSubscriptions, source$, observerOrNext]);
+  }, [hookSubscriptions, source$]);
 
   useEffect(() => {
     return () => hookSubscriptions.unsubscribe();
@@ -41,3 +85,17 @@ export function useObserver<T>(
 
   return hookSubscriptions;
 }
+
+function isBrowser() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return typeof window !== 'undefined';
+}
+
+/**
+ * Prevent React warning when using useLayoutEffect on server.
+ */
+const useIsomorphicLayoutEffect = isBrowser()
+  ? useLayoutEffect
+  : /* istanbul ignore next: both are not called on server */
+    useEffect;

--- a/packages/rx-effects-react/src/useObserver.ts
+++ b/packages/rx-effects-react/src/useObserver.ts
@@ -50,22 +50,16 @@ export function useObserver<T>(
         }
       },
       error: (error) => {
-        if (typeof argsRef.current === 'function') {
-          return;
-        }
-
-        const errorObserver = argsRef.current.error;
+        const errorObserver =
+          typeof argsRef.current !== 'function' && argsRef.current.error;
 
         if (errorObserver) {
           return errorObserver(error);
         }
       },
       complete: () => {
-        if (typeof argsRef.current === 'function') {
-          return;
-        }
-
-        const completeObserver = argsRef.current.complete;
+        const completeObserver =
+          typeof argsRef.current !== 'function' && argsRef.current.complete;
 
         if (completeObserver) {
           return completeObserver();
@@ -92,7 +86,7 @@ export function isBrowser() {
 /**
  * Prevent React warning when using useLayoutEffect on server.
  */
-const useIsomorphicLayoutEffect = isBrowser()
+export const useIsomorphicLayoutEffect = isBrowser()
   ? useLayoutEffect
   : /* istanbul ignore next: both are not called on server */
     useEffect;

--- a/packages/rx-effects-react/src/useObserver.ts
+++ b/packages/rx-effects-react/src/useObserver.ts
@@ -23,7 +23,7 @@ export function useObserver<T>(
 ): Subscription {
   const hookSubscriptions = useConst(() => new Subscription());
 
-  const argsRef = useRef<Partial<Observer<T>>>({});
+  const argsRef = useRef<Partial<Observer<T>>>();
 
   // Update the latest observable and callbacks
   // synchronously after render being committed
@@ -40,9 +40,9 @@ export function useObserver<T>(
     }
 
     const subscription = source$.subscribe({
-      next: (value) => argsRef.current.next?.(value),
-      error: (error) => argsRef.current.error?.(error),
-      complete: () => argsRef.current.complete?.(),
+      next: (value) => argsRef.current?.next?.(value),
+      error: (error) => argsRef.current?.error?.(error),
+      complete: () => argsRef.current?.complete?.(),
     });
     hookSubscriptions.add(subscription);
     return () => subscription.unsubscribe();

--- a/packages/rx-effects/src/scope.ts
+++ b/packages/rx-effects/src/scope.ts
@@ -133,10 +133,7 @@ export function createScope(): Scope {
       source: Observable<T>,
       nextOrObserver?: Partial<Observer<T>> | ((value: T) => unknown),
     ): Subscription {
-      const subscription =
-        typeof nextOrObserver === 'function'
-          ? source.subscribe(nextOrObserver)
-          : source.subscribe(nextOrObserver);
+      const subscription = source.subscribe(nextOrObserver);
 
       registerTeardown(subscription);
 


### PR DESCRIPTION
For write less code

before:
```js
 const observer = useCallback((nextValue) => {...}, [])
 useObserver(source$, observer);
```

after:
```js
 useObserver(source$, (nextValue) => {
   logger.log(nextValue);
 });
```