### PR TITLE
feat: new declareStore factory

### DIFF
--- a/packages/rx-effects/src/declareStore.test.ts
+++ b/packages/rx-effects/src/declareStore.test.ts
@@ -74,8 +74,6 @@ describe('createStore()', () => {
     localStore.updates.increment();
 
     expect(get().userId).toBe(102);
-
-    expect(localStore.getInitialState().userId).toBe(101);
   });
 
   it('should update initial state during initialization', () => {
@@ -89,6 +87,19 @@ describe('createStore()', () => {
     expect(get().count).toBe(12);
 
     expect(get().value).toBe('new initial text');
+  });
+
+  it('should initial state to be able to be a function', () => {
+    const simpleStore = createSimpleStore((state) => ({
+      ...state,
+      value: 'updated text',
+    }));
+
+    const { get } = simpleStore.asQuery();
+
+    expect(get().count).toBe(0);
+
+    expect(get().value).toBe('updated text');
   });
 
   it('should update the state', () => {
@@ -126,60 +137,6 @@ describe('createStore()', () => {
     simpleStore.updates.sum(1, 11);
 
     expect(get().count).toBe(12);
-  });
-
-  it('should get initial state without mutation after executing updates', () => {
-    const simpleStore = createSimpleStore();
-    const { get } = simpleStore.asQuery();
-
-    expect(get().count).toBe(0);
-
-    simpleStore.updates.increment();
-
-    expect(get().count).toBe(1);
-
-    expect(simpleStore.getInitialState().count).toBe(0);
-  });
-
-  it('should reset changed state to initial state', () => {
-    const simpleStore1 = createSimpleStore();
-    const simpleStore1Query = simpleStore1.asQuery();
-
-    const simpleStore2 = createSimpleStore({
-      count: 100,
-      value: 'new value',
-    });
-    const simpleStore2Query = simpleStore2.asQuery();
-
-    const simpleStore3 = createSimpleStore((state) => ({
-      ...state,
-      count: 12,
-    }));
-    const simpleStore3Query = simpleStore3.asQuery();
-
-    simpleStore1.updates.increment();
-
-    simpleStore2.updates.increment();
-
-    simpleStore3.updates.increment();
-
-    expect(simpleStore1Query.get().count).toBe(1);
-
-    expect(simpleStore2Query.get().count).toBe(101);
-
-    expect(simpleStore3Query.get().count).toBe(13);
-
-    simpleStore1.reset();
-
-    simpleStore2.reset();
-
-    simpleStore3.reset();
-
-    expect(simpleStore1Query.get().count).toBe(0);
-
-    expect(simpleStore2Query.get().count).toBe(100);
-
-    expect(simpleStore3Query.get().count).toBe(12);
   });
 
   it('should use custom comparator', () => {

--- a/packages/rx-effects/src/declareStore.test.ts
+++ b/packages/rx-effects/src/declareStore.test.ts
@@ -53,29 +53,6 @@ describe('createStore()', () => {
     expect(initialState.count).toBe(0);
   });
 
-  it('should initial state be function for declareStore', () => {
-    const createLocalStore = declareStore({
-      initialState: () => ({ userId: 101 }),
-      updates: {
-        increment: () => (state) => {
-          return {
-            ...state,
-            userId: state.userId + 1,
-          };
-        },
-      },
-    });
-
-    const localStore = createLocalStore();
-    const { get } = localStore.asQuery();
-
-    expect(get().userId).toBe(101);
-
-    localStore.updates.increment();
-
-    expect(get().userId).toBe(102);
-  });
-
   it('should update initial state during initialization', () => {
     const simpleStore = createSimpleStore({
       count: 12,
@@ -137,32 +114,5 @@ describe('createStore()', () => {
     simpleStore.updates.sum(1, 11);
 
     expect(get().count).toBe(12);
-  });
-
-  it('should use custom comparator', () => {
-    const createLocalStore = declareStore({
-      initialState: () => ({ userId: 101 }),
-      updates: {
-        increment: () => (state) => {
-          return {
-            ...state,
-            userId: state.userId + 1,
-          };
-        },
-      },
-      comparator: (prevState, nextState) => prevState === nextState,
-    });
-
-    const localStore = createLocalStore(
-      { userId: 1 },
-      { comparator: (prevState, nextState) => prevState === nextState },
-    );
-    const { get } = localStore.asQuery();
-
-    expect(get().userId).toBe(1);
-
-    localStore.updates.increment();
-
-    expect(get().userId).toBe(2);
   });
 });

--- a/packages/rx-effects/src/declareStore.test.ts
+++ b/packages/rx-effects/src/declareStore.test.ts
@@ -1,0 +1,211 @@
+import { declareStore } from './declareStore';
+
+describe('createStore()', () => {
+  type SimpleState = {
+    value: string;
+    count: number;
+  };
+  const initialState: SimpleState = {
+    value: 'initial text',
+    count: 0,
+  };
+  const createSimpleStore = declareStore({
+    initialState,
+    updates: {
+      set: (value: number) => (state) => {
+        return {
+          ...state,
+          count: value,
+        };
+      },
+      sum: (value1: number, value2: number) => (state) => {
+        return {
+          ...state,
+          count: value1 + value2,
+        };
+      },
+      increment: () => (state) => {
+        return {
+          ...state,
+          count: state.count + 1,
+        };
+      },
+      decrement: () => (state) => {
+        return {
+          ...state,
+          count: state.count - 1,
+        };
+      },
+    },
+  });
+
+  it('should allow testing of updates', () => {
+    expect(initialState.count).toBe(0);
+
+    const result = createSimpleStore.updates.set(10)(initialState);
+
+    expect(result.count).toBe(10);
+  });
+
+  it('should executing without mutation for initial state', () => {
+    createSimpleStore.updates.set(10)(initialState);
+
+    expect(initialState.count).toBe(0);
+  });
+
+  it('should initial state be function for declareStore', () => {
+    const createLocalStore = declareStore({
+      initialState: () => ({ userId: 101 }),
+      updates: {
+        increment: () => (state) => {
+          return {
+            ...state,
+            userId: state.userId + 1,
+          };
+        },
+      },
+    });
+
+    const localStore = createLocalStore();
+    const { get } = localStore.asQuery();
+
+    expect(get().userId).toBe(101);
+
+    localStore.updates.increment();
+
+    expect(get().userId).toBe(102);
+
+    expect(localStore.getInitialState().userId).toBe(101);
+  });
+
+  it('should update initial state during initialization', () => {
+    const simpleStore = createSimpleStore({
+      count: 12,
+      value: 'new initial text',
+    });
+
+    const { get } = simpleStore.asQuery();
+
+    expect(get().count).toBe(12);
+
+    expect(get().value).toBe('new initial text');
+  });
+
+  it('should update the state', () => {
+    const simpleStore = createSimpleStore();
+    const { get } = simpleStore.asQuery();
+    expect(get().count).toBe(0);
+
+    simpleStore.updates.set(10);
+
+    expect(get().count).toBe(10);
+
+    simpleStore.updates.increment();
+
+    expect(get().count).toBe(11);
+
+    simpleStore.updates.decrement();
+    simpleStore.updates.decrement();
+
+    expect(get().count).toBe(9);
+  });
+
+  it('should execute query selector', () => {
+    const simpleStore = createSimpleStore();
+    const { get } = simpleStore.query((state) => state.count);
+
+    simpleStore.updates.set(1);
+
+    expect(get()).toBe(1);
+  });
+
+  it('should use a lot of arguments in updates', () => {
+    const simpleStore = createSimpleStore();
+    const { get } = simpleStore.asQuery();
+
+    simpleStore.updates.sum(1, 11);
+
+    expect(get().count).toBe(12);
+  });
+
+  it('should get initial state without mutation after executing updates', () => {
+    const simpleStore = createSimpleStore();
+    const { get } = simpleStore.asQuery();
+
+    expect(get().count).toBe(0);
+
+    simpleStore.updates.increment();
+
+    expect(get().count).toBe(1);
+
+    expect(simpleStore.getInitialState().count).toBe(0);
+  });
+
+  it('should reset changed state to initial state', () => {
+    const simpleStore1 = createSimpleStore();
+    const simpleStore1Query = simpleStore1.asQuery();
+
+    const simpleStore2 = createSimpleStore({
+      count: 100,
+      value: 'new value',
+    });
+    const simpleStore2Query = simpleStore2.asQuery();
+
+    const simpleStore3 = createSimpleStore((state) => ({
+      ...state,
+      count: 12,
+    }));
+    const simpleStore3Query = simpleStore3.asQuery();
+
+    simpleStore1.updates.increment();
+
+    simpleStore2.updates.increment();
+
+    simpleStore3.updates.increment();
+
+    expect(simpleStore1Query.get().count).toBe(1);
+
+    expect(simpleStore2Query.get().count).toBe(101);
+
+    expect(simpleStore3Query.get().count).toBe(13);
+
+    simpleStore1.reset();
+
+    simpleStore2.reset();
+
+    simpleStore3.reset();
+
+    expect(simpleStore1Query.get().count).toBe(0);
+
+    expect(simpleStore2Query.get().count).toBe(100);
+
+    expect(simpleStore3Query.get().count).toBe(12);
+  });
+
+  it('should use custom comparator', () => {
+    const createLocalStore = declareStore({
+      initialState: () => ({ userId: 101 }),
+      updates: {
+        increment: () => (state) => {
+          return {
+            ...state,
+            userId: state.userId + 1,
+          };
+        },
+      },
+      comparator: (prevState, nextState) => prevState === nextState,
+    });
+
+    const localStore = createLocalStore(
+      { userId: 1 },
+      { comparator: (prevState, nextState) => prevState === nextState },
+    );
+    const { get } = localStore.asQuery();
+
+    expect(get().userId).toBe(1);
+
+    localStore.updates.increment();
+
+    expect(get().userId).toBe(2);
+  });
+});

--- a/packages/rx-effects/src/declareStore.ts
+++ b/packages/rx-effects/src/declareStore.ts
@@ -1,0 +1,293 @@
+import { Observable } from 'rxjs';
+import { Query } from './query';
+import { createStore, createStoreUpdates, StoreUpdateFunction } from './store';
+
+type DeepReadonly<T> = T extends (infer R)[]
+  ? DeepReadonlyArray<R>
+  : T extends (...any: any[]) => any
+  ? T
+  : T extends object
+  ? DeepReadonlyObject<T>
+  : T;
+
+type DeepReadonlyArray<T> = ReadonlyArray<DeepReadonly<T>>;
+
+type DeepReadonlyObject<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
+type CaseUpdater<S = any, P = any> = (
+  ...payload: P[]
+) => (state: DeepReadonly<S>) => DeepReadonly<S>;
+
+type StoreCaseUpdates<State> = {
+  [K: string]: CaseUpdater<State, any>;
+};
+
+type ActionCreatorForCaseUpdater<CR> = CR extends (...payload: infer P) => any
+  ? ActionCreator<P>
+  : () => void;
+
+type ActionCreator<P extends any[] = any[]> = IsAny<
+  P,
+  (...payload: any[]) => void,
+  IsUnknownOrNonInferrable<
+    P,
+    () => void,
+    IfVoid<
+      P,
+      (...payload: void[]) => void,
+      IfMaybeUndefined<
+        P,
+        (...payload: undefined[]) => void,
+        (...payload: P) => void
+      >
+    >
+  >
+>;
+
+type CaseUpdaterActions<CaseUpdaters extends StoreCaseUpdates<any>> = {
+  [Type in keyof CaseUpdaters]: ActionCreatorForCaseUpdater<CaseUpdaters[Type]>;
+};
+
+type IsAny<T, True, False = never> =
+  // test if we are going the left AND right path in the condition
+  true | false extends (T extends never ? true : false) ? True : False;
+
+type IsUnknown<T, True, False = never> = unknown extends T
+  ? IsAny<T, False, True>
+  : False;
+
+type AtLeastTS35<True, False> = [True, False][IsUnknown<
+  ReturnType<<T>() => T>,
+  0,
+  1
+>];
+
+type IfMaybeUndefined<P, True, False> = [undefined] extends [P] ? True : False;
+
+type IfVoid<P, True, False> = [void] extends [P] ? True : False;
+
+type IsEmptyObj<T, True, False = never> = T extends any
+  ? keyof T extends never
+    ? IsUnknown<T, False, IfMaybeUndefined<T, False, IfVoid<T, False, True>>>
+    : False
+  : never;
+
+type IsUnknownOrNonInferrable<T, True, False> = AtLeastTS35<
+  IsUnknown<T, True, False>,
+  IsEmptyObj<T, True, IsUnknown<T, True, False>>
+>;
+
+type QueryOptions<T, K> = Readonly<{
+  distinct?:
+    | boolean
+    | {
+        comparator?: (previous: K, current: K) => boolean;
+        keySelector?: (value: T) => K;
+      };
+}>;
+
+interface StoreResult<
+  State = any,
+  CaseUpdaters extends StoreCaseUpdates<State> = StoreCaseUpdates<State>,
+  Name extends string = string,
+> {
+  readonly name: Name | undefined;
+  readonly updates: CaseUpdaterActions<CaseUpdaters>;
+  readonly get: () => DeepReadonly<State>;
+
+  /**
+   * Cast the store to a narrowed `Query` type.
+   */
+  readonly asQuery: () => Query<DeepReadonly<State>>;
+  readonly value$: Observable<DeepReadonly<State>>;
+  readonly destroy: () => void;
+  readonly select: <R, K = R>(
+    selector: (state: DeepReadonly<State>) => R,
+    options?: QueryOptions<R, K>,
+  ) => Observable<R>;
+
+  readonly query: <R, K = R>(
+    selector: (state: DeepReadonly<State>) => R,
+    options?: QueryOptions<R, K>,
+  ) => Query<R>;
+
+  readonly update: StoreUpdateFunction<DeepReadonly<State>>;
+
+  readonly id: number;
+  readonly getInitialState: () => DeepReadonly<State>;
+  readonly reset: () => void;
+}
+
+interface StoreOptions<State> {
+  /** A comparator for detecting changes between old and new states */
+  comparator?: (
+    prevState: DeepReadonly<State>,
+    nextState: DeepReadonly<State>,
+  ) => boolean;
+
+  /** Callback is called when the store is destroyed */
+  onDestroy?: () => void;
+}
+
+interface StoreProps<
+  InitialState,
+  State = InitialState extends () => infer S ? S : InitialState,
+  Updates extends StoreCaseUpdates<State> = StoreCaseUpdates<State>,
+  Name extends string = string,
+> {
+  name?: Name;
+
+  initialState: InitialState;
+
+  updates: Updates;
+  /** A comparator for detecting changes between old and new states */
+  comparator?: (
+    prevState: DeepReadonly<State>,
+    nextState: DeepReadonly<State>,
+  ) => boolean;
+}
+
+type DeclareStoreResultFn<
+  State,
+  CaseUpdates extends StoreCaseUpdates<State>,
+> = (
+  initialState?: DeepReadonly<State> | StateMutation<State> | null,
+  options?: StoreOptions<State>,
+) => StoreResult<State, CaseUpdates>;
+
+interface DeclareStoreResult<
+  State,
+  CaseUpdates extends StoreCaseUpdates<State>,
+> {
+  (
+    initialState?: DeepReadonly<State> | StateMutation<State> | null,
+    options?: StoreOptions<State>,
+  ): StoreResult<State, CaseUpdates>;
+  updates: CaseUpdates;
+}
+
+/**
+ * declare the base interface for create store
+ * @example 
+```ts
+type State = {
+  id: string;
+  name: string;
+  isAdmin: boolean
+};
+const initialState: State = {
+  id: '',
+  name: '',
+  isAdmin: false
+};
+const createUserStore = declareStore({
+  initialState,
+  updates: {
+    setId: (id: string) => (state) => {
+      return {
+        ...state,
+        id: id,
+      };
+    },
+    setName: (name: string) => (state) => {
+      return {
+        ...state,
+        name: name,
+      };
+    },
+    update: (id: string name: string) => (state) => {
+      return {
+        ...state,
+        id: id,
+        name: name,
+      };
+    },
+    setIsAdmin: () => (state) => {
+      return {
+        ...state,
+        isAdmin: true,
+      };
+    },
+  },
+});
+
+const userStore1 = createUserStore({ id: '1', name: 'User 1', isAdmin: false });
+
+const userStore2 = createUserStore({ id: '2', name: 'User 2', isAdmin: true });
+
+// OR
+
+const users = [
+  createUserStore({id: 1, name: 'User 1'}),
+  createUserStore({id: 2, name: 'User 2'}),
+]
+
+userStore1.updates.setName('User from store 1');
+
+assets.isEqual(userStore1.get().name, 'User from store 1')
+
+assets.isEqual(userStore2.get().name, 'User 2')
+
+// type of createUserStore
+type UserStore = ReturnType<typeof createUserStore>;
+```
+ */
+export function declareStore<
+  InitialState,
+  State = InitialState extends () => infer S ? S : InitialState,
+  CaseUpdates extends StoreCaseUpdates<State> = StoreCaseUpdates<State>,
+>(
+  props: StoreProps<InitialState, State, CaseUpdates>,
+): DeclareStoreResult<State, CaseUpdates> {
+  const { initialState, updates, name, comparator } = props;
+
+  const _state =
+    typeof initialState === 'function' ? initialState() : initialState;
+
+  const result: DeclareStoreResultFn<State, CaseUpdates> = function (
+    initialState,
+    options = {},
+  ) {
+    const _initialState = initialState
+      ? typeof initialState === 'function'
+        ? (initialState as StateMutation<State>)({ ..._state })
+        : initialState
+      : _state;
+
+    const _store = createStore<DeepReadonly<State>>(_initialState, {
+      comparator: options.comparator ?? comparator,
+      name,
+      onDestroy: options.onDestroy,
+    });
+
+    return {
+      name,
+      updates: createStoreUpdates(
+        _store.update,
+        updates,
+      ) as CaseUpdaterActions<CaseUpdates>,
+      value$: _store.value$,
+      get: _store.get,
+      asQuery: _store.asQuery,
+      destroy: _store.destroy,
+      select: _store.select,
+      query: _store.query,
+      update: _store.update,
+      id: _store.id,
+      reset: () => {
+        _store.update(() => _initialState);
+      },
+      getInitialState: () => {
+        return _initialState;
+      },
+    };
+  };
+
+  Object.assign(result, { updates });
+
+  return result as DeclareStoreResult<State, CaseUpdates>;
+}
+
+type StateMutation<State> = (state: DeepReadonly<State>) => DeepReadonly<State>;

--- a/packages/rx-effects/src/index.ts
+++ b/packages/rx-effects/src/index.ts
@@ -45,3 +45,5 @@ export { registerStoreExtension } from './storeExtensions';
 export { createStoreLoggerExtension } from './storeLoggerExtension';
 
 export { OBJECT_COMPARATOR } from './utils';
+
+export { declareStore } from './declareStore';


### PR DESCRIPTION
I prepared a new syntax for declare store. What do you think?
before
```ts
type State = {
  id: string;
};
const USER_STATE = {  
  id: string 
};
const USER_STATE_UPDATES = declareStateUpdates<State>()({
  setId: (id: number) => (state) => ({
    ...state,
    id: id,
  }),
});

 type UserStore = StoreWithUpdates<
  State,
  typeof USER_STATE_UPDATES
>;

const createUserStore = declareStoreWithUpdates(
  USER_STATE,
  USER_STATE_UPDATES,
  { name: 'UserStore' },
);

const userStore = createUserStore();
// OR
const userStore = createUserStore({id: 1});

userStore.updates.setId('2')
```

after

```ts
type State = {
  id: string;
};
const initialState: State = {
  id: '',
};
const createUserStore = declareStore({
  initialState,
  updates: {
    setId: (id: string) => (state) => ({
        ...state,
        id: id,
    }),
  },
});

type UserStore = ReturnType<typeof createUserStore>;

const userStore = createUserStore();
// OR
const userStore = createUserStore({ id: '1' });

userStore.updates.setId('2')

```